### PR TITLE
Explain what a 512K or 1M context window would take

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,10 @@ Optimise for the ratio you actually have, not the one the benchmarks advertise.
 - One OpenAI-compatible endpoint (`/v1/...`) on the head node's port `8000`,
   backed by all four Sparks acting as a single TP4 engine.
 - Served model id: `glm-5.3-flash`.
-- Context window up to **262,144** tokens.
+- Context window up to **262,144** tokens. The model itself is rated to **1M**
+  — the shipped window is a deliberate trade, and
+  [`docs/long-context.md`](docs/long-context.md) works through exactly what
+  512K or 1M would take, and what it would cost in KV.
 - Warm decode in the region of **48–51 tokens/s** for code (up to ~72 t/s warm),
   prefill around **1,800 t/s at 32–64K** — roughly the bottom commercial
   GLM-5.3 tier, on hardware you own.
@@ -207,6 +210,7 @@ in step 4 passes — see [`docs/recipe.md`](docs/recipe.md) §5.
 │   ├── recipe.md             # the full detailed recipe, end to end
 │   ├── fabric.md             # the ring fabric addressing template + MTU
 │   ├── switches.md           # switched alternatives (100/400 GbE) + supply chain
+│   ├── long-context.md       # 512K / 1M: the KV arithmetic + how to gate it
 │   └── gotchas.md            # failure modes and the fixes
 └── scripts/
     ├── fabric-setup.sh       # apply ring addressing + MTU (edit vars at top)

--- a/docs/long-context.md
+++ b/docs/long-context.md
@@ -1,0 +1,87 @@
+# 512K and 1M context — what it would take
+
+The most common question about this recipe: *why does it ship
+`--max-model-len 262144` when the model is rated to 1M?* Short answer: 262K is
+the **validated, multi-user envelope**, not a ceiling. GLM-5.3-Flash is natively
+trained to **1,048,576 positions** (`max_position_embeddings` in `config.json`),
+and it is a NoPE model — there is no RoPE scaling or extrapolation trick
+involved in going deeper. Both 512K and 1M are reachable with flag changes.
+
+What follows is the exact arithmetic, what it costs you, and how to gate it if
+you go there. If you want 1M — do it; this page is what your agent needs.
+
+## The KV arithmetic
+
+Measured on the running build (rank-0 log):
+
+```
+reserved 12.0 GiB memory for KV Cache
+GPU KV cache size: 786,432 tokens, Maximum concurrency for 262,144 tokens per request: 3.00x
+```
+
+12 GiB ÷ 786,432 tokens = **16 KiB of KV per token, per rank** (bf16 KV — see
+[`recipe.md`](recipe.md) for why FP8 KV is the wrong trade on this model).
+Every projection below is that one measured number, scaled linearly:
+
+| Window | Min pool for one full-depth stream | Suggested `--kv-cache-memory` | Full-depth streams at suggested |
+|---|---|---|---|
+| **262,144** (shipped) | 4 GiB | 12 GiB (`12884901888`) | 3.0 |
+| **524,288** | 8 GiB | **12 GiB — unchanged** | 1.5 |
+| **1,048,576** | 16 GiB (boundary-exact) | 18 GiB (`19327352832`) | 1.125 |
+
+- **512K is one flag.** `--max-model-len 524288`, nothing else. The shipped
+  12 GiB pool already holds 1.5 full-depth streams, and shallow requests share
+  the same pool exactly as before.
+- **1M is two flags.** `--max-model-len 1048576` plus a bigger pool. 16 GiB
+  works out to 1,048,576 tokens *to the token* — a boundary-exact pool leaves
+  no margin for block rounding or the speculative-decode lookahead, so take
+  18 GiB and keep 12.5% headroom.
+
+## What it costs
+
+- **Cold TTFT becomes minutes.** Cold prefill measures ~2,000–2,300 tok/s on
+  this deployment, so a full cold window is roughly **4–4.5 minutes at 512K**
+  and **8–9 minutes at 1M**. Prefix-cache reuse still applies — it is the first
+  deep prefill that hurts, and every user should know that number before you
+  advertise the window.
+- **Validation stops at 229K.** Needle retrieval is proven at 30K / 119K /
+  229K; nothing beyond that has been measured here — neither retrieval quality
+  nor decode speed at depth. A pass at 229K says nothing about 500K.
+- **The pool is shared.** One 1M request occupies ~89% of an 18 GiB pool.
+  `--max-num-seqs 6` does not protect concurrent users from a single deep
+  request — they get queued or preempted behind it. The shipped config's 3.0×
+  concurrency at full depth is a feature, and this trades it away.
+- **The hard-hang zone is real.** 12 GiB is the known-safe pool on a 128 GiB
+  GB10. 24 GiB combined with `--max-num-batched-tokens 8192` produced an OOM
+  **hard-hang** — a wedged node, not a clean error (see
+  [`gotchas.md`](gotchas.md)). 16–18 GiB is untested middle ground: raise the
+  pool in one step, watch the whole bring-up, and be ready to power-cycle.
+- **Check your demand first.** Across 476 real agentic requests through this
+  deployment, the deepest prompt was **122K** — under half the shipped window.
+  Ship a bigger window because your traffic needs it, not for the README.
+
+## If you want it
+
+In [`scripts/rank-launcher.sh`](../scripts/rank-launcher.sh), on **all four
+ranks** (the serve arguments must match across the TP group):
+
+```bash
+# 512K — one change:
+--max-model-len 524288
+
+# 1M — two changes:
+--max-model-len 1048576
+--kv-cache-memory 19327352832        # 18 GiB; 16 GiB is the boundary-exact minimum
+```
+
+Relaunch in the usual order (workers 3 → 2 → 1, then the head), then gate it
+before trusting it:
+
+1. Run [`scripts/gate.sh`](../scripts/gate.sh) as shipped.
+2. Extend the needle depth towards the new window (~0.9× is a fair probe) — and
+   time a full-window cold prefill so you can quote the real TTFT.
+3. If a node wedges with no error and the container is unreachable, that is the
+   OOM hard-hang: power-cycle the node, drop the pool a notch, and re-gate.
+
+Nothing else in the recipe changes — fabric, patched NCCL, drafter, and parsers
+all carry over as-is.

--- a/docs/recipe.md
+++ b/docs/recipe.md
@@ -136,10 +136,13 @@ Notes on the choices:
   the native `fp8_ds_mla` format, but GLM-5.3-Flash is **NoPE**-MLA and does not
   fit the `fp8_ds_mla` path (a `pe_dim` mismatch) — so the clean choice here is
   bf16. Because MLA keeps the KV small, bf16 still yields a large pool
-  (**≈ 811,800 tokens, ~3.1× the 262K window**) and costs nothing on decode.
+  (**786,432 tokens, 3.0× the 262K window** — the rank-0 log prints it at
+  start-up) and costs nothing on decode.
   Validated: mid-context needle retrieval passes at **30K / 119K / 229K** tokens.
   The pool is capped at 12 GiB on purpose — chasing it higher risks an OOM
   **hard-hang** on a node (not a clean error). See [`gotchas.md`](gotchas.md).
+  Wondering about a 512K or 1M window instead? The arithmetic and the gating
+  steps are worked through in [`long-context.md`](long-context.md).
 - **DFlash speculative config, `num_speculative_tokens: 7`** — the DFlash2 drafter
   mounted at `/draft`; 7 is the tuned depth for this pairing.
 - **`--tool-call-parser glm47 --reasoning-parser glm45`** — GLM-5.3 emits


### PR DESCRIPTION
Answers the recurring "why not 1M?" question with a page readers (or their agents) can act on: docs/long-context.md.

**What's in it:**
- The measured KV arithmetic from the running build: 12 GiB/rank serves 786,432 tokens = **16 KiB per token per rank** (bf16 KV), scaled to a table for 256K / 512K / 1M.
- 512K is a single flag (`--max-model-len 524288`) — the shipped pool already holds 1.5 full-depth streams. 1M needs the pool raised to 18 GiB (16 GiB is boundary-exact with no margin).
- The honest costs: cold TTFT of ~4.5 min at 512K and ~9 min at 1M, validation stopping at the 229K needle, one deep request monopolising the shared pool, and the OOM hard-hang zone above the shipped 12 GiB.
- A gate-before-trusting checklist for anyone who raises the window.

**Also:** corrects the quoted KV pool in recipe.md (the current build reports 786,432 tokens / 3.0×, not ~811,800), and links the new page from the README bullet, the repo layout, and the serve-argument notes.